### PR TITLE
SRCNN_Cpp macOS compatibility updated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Pictures/*_resized.*
 testout.png
 *.o
 *.bak
+.DS-Store

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -1,8 +1,8 @@
 # Makefiel for SRCNN git cloned mod.
 # by Raphael Kim
 
-CPP = gcc
-CXX = g++
+CPP = llvm-gcc
+CXX = llvm-g++
 AR  = ar
 
 # sense macOS kernel type
@@ -12,8 +12,10 @@ KRNL_VER  = $(shell uname -r | cut -d . -f1)
 KERNELID  = $(KERNEL)
 MACHINEID = universal
 
-OPENCV_INCS = `pkg-config opencv4 --static --cflags`
-OPENCV_LIBS = `pkg-config opencv4 --static --libs`
+# remind, macOS brew don't provides universal binary -
+OPENCV_INCS = $(shell pkg-config opencv4 --cflags)
+OPENCV_LIBS = $(shell pkg-config opencv4 --libs)
+USE_STATIC_OPENCV = 0
 
 SRC_PATH = src
 OBJ_PATH = obj
@@ -23,24 +25,25 @@ TARGET   = srcnn
 SRCS = $(wildcard $(SRC_PATH)/*.cpp)
 OBJS = $(SRCS:$(SRC_PATH)/%.cpp=$(OBJ_PATH)/%.o)
 
-CFLAGS  = -mtune=native
+CFLAGS += -std=c++11
 CFLAGS += -I$(SRC_PATH)
 CFLAGS += $(OPENCV_INCS)
-CLFAGS += -DNO_OMP
+CFLAGS += -DNO_OMP
 
 # Static build may require static-configured openCV.
 LFLAGS  = 
 LFLAGS += $(OPENCV_LIBS)
-LFLAGS += -static-libgcc -static-libstdc++
-LFLAGS += -s -ffast-math -O3
+LFLAGS += -ffast-math -O3
 
 # architecture flag setting.
 # Darwin, kernel 20 (big sur) automatically using universal binary.
-ifeq ($(KERNEL),Darwin)
-    ifeq ($(shell test $(KRNL_VER) -gt 19; echo $$?),0)
-        CFLAGS += -arch x86_64 -arch arm64
-        CFLAGS += -mmacosx-version-min=11.0
-        LFLAGS += -arch x86_64 -arch arm64
+ifeq ($(USE_STATIC_OPENCV),1)
+    ifeq ($(KERNEL),Darwin)
+        ifeq ($(shell test $(KRNL_VER) -gt 19; echo $$?),0)
+            CFLAGS += -arch x86_64 -arch arm64
+            CFLAGS += -mmacosx-version-min=11.0
+            LFLAGS += -arch x86_64 -arch arm64
+        endif
     endif
 endif
 
@@ -51,7 +54,6 @@ all: prepare $(BIN_PATH)/$(TARGET)
 prepare:
 	@mkdir -p $(OBJ_PATH)
 	@mkdir -p $(BIN_PATH)
-	@echo $(SRCS)
 
 clean:
 	@rm -rf $(OBJ_PATH)/*.o
@@ -63,5 +65,5 @@ $(OBJS): $(OBJ_PATH)/%.o: $(SRC_PATH)/%.cpp
 
 $(BIN_PATH)/$(TARGET): $(OBJS)
 	@echo "Linking $@ ..."
-	@$(CXX) $(OBJ_PATH)/*.o $(CFLAGS) $(LFLAGS) -o $@
+	@$(CXX) $^ $(CFLAGS) $(LFLAGS) -o $@
 

--- a/src/srcnn.cpp
+++ b/src/srcnn.cpp
@@ -95,8 +95,9 @@ void Convolution99(Mat& src, Mat& dst, const float kernel[9][9], float bias)
     int height = dst.rows;
     int row    = 0;
     int col    = 0;
-    int rowf[height + 8] = {0};
-    int colf[width + 8]  = {0};
+    // macOS clang displays these array not be initialized.
+    int rowf[height + 8];
+    int colf[width + 8];
 
     /* Expand the src image */
     #pragma parallel for
@@ -191,9 +192,9 @@ void Convolution55(vector<Mat>& src, Mat& dst, const float kernel[32][5][5], flo
     int width  = dst.cols;
     int row    = 0;
     int col    = 0;
-    unsigned cnt;
-    int rowf[height + 4] = {0};
-    int colf[width + 4] = {0};
+    // macOS these array not be initalized by zero.
+    int rowf[height + 4];
+    int colf[width + 4];
 
     /* Expand the src image */
     #pragma omp parallel for
@@ -261,8 +262,9 @@ void Convolution99x11( Mat& src, vector<Mat>& dst, \
     int height = src.rows;
     int width = src.cols;
     float temp[CONV1_FILTERS] = {0.f};
-    int rowf[height + 8] = {0};
-    int colf[width + 8] = {0};
+    // macOS llvm not able to init zero.
+    int rowf[height + 8];
+    int colf[width + 8];
 
     /* Expand the src image */
     #pragma omp parallel for


### PR DESCRIPTION
Dear @shuwang127 ,
There are some codes and Makefile for macOS updated these :

1. homebrew not installs universal binary openCV4.
1. So I made non-static build type for Makefile.macos
1. Updated clang 14.0.0 ( macOS 12 ) occurs error on variable array zero initializing.

Hope it should help support macOS support.
And check my latest update of [libsrcnn for homebrew-llvm + openMP on macOS performance update](https://github.com/rageworx/libsrcnn/issues/13), it's dramatic.
